### PR TITLE
Use padding parameter in Scaffold content composable

### DIFF
--- a/app/src/main/java/com/xmartlabs/gong/ui/screens/welcome/WelcomeScreen.kt
+++ b/app/src/main/java/com/xmartlabs/gong/ui/screens/welcome/WelcomeScreen.kt
@@ -3,6 +3,7 @@ package com.xmartlabs.gong.ui.screens.welcome
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Scaffold
 import androidx.compose.material.Text
@@ -47,10 +48,10 @@ fun WelcomeContent(
 ) {
     Scaffold(
         topBar = { AppTopBar() },
-    ) {
+    ) { padding ->
         Column(
             verticalArrangement = Arrangement.Center,
-            modifier = Modifier.fillMaxSize()
+            modifier = Modifier.fillMaxSize().padding(padding)
         ) {
             Text(
                 text = "Hi $userName",


### PR DESCRIPTION
## Description:

Since Compose 1.2.0 it's required to use padding parameter, passed into Scaffold content composable. It should be applied to the topmost container/view in content.
